### PR TITLE
move gzip to use stage3 repo

### DIFF
--- a/gzip.yaml
+++ b/gzip.yaml
@@ -16,9 +16,9 @@ package:
 environment:
   contents:
     repositories:
-      - https://packages.wolfi.dev/bootstrap/stage2
+      - https://packages.wolfi.dev/bootstrap/stage3
     keyring:
-      - https://packages.wolfi.dev/bootstrap/stage2/wolfi-signing.rsa.pub
+      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle


### PR DESCRIPTION
Switch gzip package to use stage3 repo


Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>